### PR TITLE
Added decode! function and made consistent with core Base module

### DIFF
--- a/lib/zbase32.ex
+++ b/lib/zbase32.ex
@@ -43,11 +43,21 @@ defmodule ZBase32 do
   Decodes a z-base-32 encoded string into a binary string.
   """
   @spec decode(String.t) :: {:ok, binary} | :error
-  def decode(<<>>), do: {:ok, <<>>}
   def decode(string) when is_binary(string) do
-    {:ok, do_decode(string)}
+    {:ok, decode!(string)}
   rescue
-    _ in [CaseClauseError, ArgumentError] -> :error
+    ArgumentError -> :error
+  end
+
+  @doc ~S"""
+  Decodes a z-base-32 encoded string into a binary string.
+
+  An ArgumentError is raised if the input string is not a z-base-32 encoded string.
+  """
+  @spec decode!(String.t) :: binary
+  def decode!(<<>>), do: <<>>
+  def decode!(string) when is_binary(string) do
+    do_decode(string)
   end
 
   defp do_decode(string) do
@@ -81,6 +91,7 @@ defmodule ZBase32 do
           dec(c7)::5, dec(c8)::5>>
       <<>> ->
         main
+      _ -> raise ArgumentError, "string must be a valid z-base-32 encoded string."
     end
   end
 

--- a/test/zbase32_test.exs
+++ b/test/zbase32_test.exs
@@ -8,19 +8,25 @@ defmodule ZBase32Test do
   test "Base64 alphabet" do
     input = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
     assert (input |> encode() |> decode()) == {:ok, input}
+    assert (input |> encode() |> decode!()) == input
   end
 
   test "gibberish" do
     assert decode("gibberish") == :error
+    assert_raise ArgumentError, fn ->
+      decode!("gibberish")
+    end
   end
 
   test "empty string" do
     assert ("" |> encode() |> decode()) == {:ok, ""}
+    assert ("" |> encode() |> decode!()) == ""
   end
 
   property "encoding" do
     forall input <- largebinary({:limit, 0, 512}) do
       ensure (input |> encode() |> decode()) == {:ok, input}
+      ensure (input |> encode() |> decode!()) == input
     end
   end
 end


### PR DESCRIPTION
I would like to use your z-base32 lib for a small effort I'm working with to implement [Multibase](https://github.com/multiformats/multibase) in Elixir. I'd prefer not to hard fork it thus the pull request.

As such, I propose a minor change that should not affect your usage or existing interface - a `decode!/1` function. Further, I got rid of the ClauseError and replaced it with a more descriptive `ArgumentError` + message to be more clear and since this is also what the Elixir [Base](https://hexdocs.pm/elixir/Base.html) lib does.

The main reason for this is I want all libs I use for Multibase to be consistent with the [Base](https://hexdocs.pm/elixir/Base.html) lib when possible. Your is consistent except for these small details. I could write an adapter, but I think this approach makes more sense. I also don't want the extra overhead of creating a tuple, only to pattern match it to take the raw result.

I tried to keep the code-style and approach the same and have added the requisite test cases to your existing ones, though you might prefer to split them.

Thanks and I hope you will accept this small PR or otherwise tweak it to your liking.